### PR TITLE
Bump the pip group across 1 directories with 1 update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ heroku3
 apscheduler
 motor 
 numpy
-pillow==9.5.0
+pillow==10.2.0
 psutil
 wget
 pyfiglet


### PR DESCRIPTION
Bumps the pip group with 1 update in the /. directory: [pillow](https://github.com/python-pillow/Pillow).


Updates `pillow` from 9.5.0 to 10.2.0
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/9.5.0...10.2.0)

---
updated-dependencies:
- dependency-name: pillow dependency-type: direct:production dependency-group: pip-security-group ...